### PR TITLE
implement proof writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Logveil is a simple CLI tool for log anonymizaiton. If you ever had a need to create a sample log data but were afraid to leak sensitive info this tool will help you make your logs anonymous.
 
+Currently LogVeil works only with Logmanager-created log data. It needs to be either LM Export (CSV) or LM Backup (GZIP).
+
+Once log data input is supplied, LogVeil will go over each log line, apply anonymization to it, output raw anonymized log to standard output or a file path provided by user and write anonymisation proof in format `{"original":"original_value","new":"new_value"}` to `proof.json` file.
+
+Note that LogVeil is made to work with data streams so it does not load whole input file to memory - which is crucial when dealing with large LM Backup files.
+
 ## Disclaimer
 
 **While LogVeil is designed to anonymize logs effectively, the outcome depends on the configuration. We recommend verifying that the data shared has been fully anonymized and contains no sensitive information!**
@@ -12,7 +18,7 @@ Logveil is a simple CLI tool for log anonymizaiton. If you ever had a need to cr
 
 There are two components needed to make this work:
 
-1. Your input log data in CSV format.
+1. Your input log data in CSV (LM Export) or GZIP (LM Backup) format.
 2. Anonymization data - which is data that will be used to replace original log data.
 
 ```
@@ -22,47 +28,89 @@ Usage of ./logveil:
   -i value
         Path to input file containing logs to be anonymized
   -o value
-        Path to output file containing anonymized logs
+        Path to output file (default: Stdout)
   -v
         Enable verbose logging
+  -e
+        Change input file type to LM export (default: LM Backup)
+  -p
+        Disable proof wrtier (default: Enabled)
   -h
         Help for logveil
 ```
 
-**Example:**
+**Examples:**
 
-`./logveil -d example_anon_data/ -i test_log.csv -o output.txt`
+1. Read log data from LM Export file (CSV), output anonymization result to `output.txt` file and write anonymization proof to `proof.json` file.
 
-### Input log data
+`./logveil -d example_anon_data/ -e -i lm_export.csv -o output.txt`
 
-Obviously first you need to provide log data to be anonymized. It needs to be in a CSV format. The columns in you CSV file will mark which values you want to anonymize.
+2. Read log data from LM Backup file (GZIP), output anonymization result to `output.txt` file and write anonymization proof to `proof.json` file.
 
-As an example consider below log line. It is formatted in a standard `key:value` format. Key names mark the values.
+`./logveil -d example_anon_data/ -i lm_backup.gz -o output.txt`
+
+3. Read log data from LM Backup file (GZIP), output anonymization result to `output.txt` file and disable writing anonymization proof.
+
+`./logveil -d example_anon_data/ -i lm_backup.gz -o output.txt -p`
+
+4. Read log data from LM Export file (CSV), output anonymization result to standard output (STDOUT) and disable writing anonymization proof.
+
+`./logveil -d example_anon_data/ -e -i lm_export.csv -p`
+
+5. Read log data from LM Export file (CSV), output anonymization result to standard output (STDOUT), disable writing anonymization proof and enable verbose logging.
+
+`./logveil -d example_anon_data/ -e -i lm_export.csv -p -v`
+
+### How it works
+
+Consider below log line. It is formatted in a common `key:value` format.
 
 ```
-{"@timestamp": "2024-06-05T14:59:27.000+00:00", "msg.src_ip":"89.239.31.49", "username":"test.user@test.cz", "organization":"TESTuser.test.com"}
+{"@timestamp": "2024-06-05T14:59:27.000+00:00", "src_ip":"89.239.31.49", "username":"test.user@test.cz", "organization":"TESTuser.test.com"}
 ```
 
-As such we can easily parse it into CSV file:
+First, LogVeil will load anonymization data from supplied directory (`-d example_anon_data/`). Each file in that folder should be named according to the values it will be masking. For example, lets assume we have following directory structure:
+
+1. `username.txt`
+2. `organization.txt`
+
+Next, LogVeil will go over each log line in supplied input and extract `key:value` pairs from it. When applied to above log line it would look like this:
+
+1. `"@timestamp": "2024-06-05T14:59:27.000+00:00"`
+2. `"src_ip":"89.239.31.49"`
+3. `"username":"test.user@test.cz"`
+4. `"organization":"TESTuser.test.com"`
+
+Then, LogVeil will try to match extracted pairs to anonymization data it loaded in previous step. Two paris should be matched:
+
+1. `"username":"test.user@test.cz"` with `username.txt`
+2. `"organization":"TESTuser.test.com"` with `organization.txt`
+
+Now LogVeil will grab a random values from files which filenames matched with keys and replace original values with them. Outcome should look like this:
+
+1. `"username":"ladislav.dosek"`
+2. `"organization":"Apple"`
+
+And thats it. Now anonymized log can be written to output along with anonymization proof:
 
 ```
-@timestamp,msg.src_ip,msg.username,msg.organization,raw
-2024-06-05T14:59:27.000+00:00,89.239.31.49,test.user@test.cz,TESTuser.test.com,"{""@timestamp"": ""2024-06-05T14:59:27.000+00:00"", ""msg.src_ip"":""89.239.31.49"", ""username"":""test.user@test.cz"", ""organization"":""TESTuser.test.com""}"
+{"@timestamp": "2024-06-05T14:59:27.000+00:00", "src_ip":"89.239.31.49", "username":"ladislav.dosek", "organization":"Apple"}
 ```
 
-Now key names are simply column names in CSV file. `raw` contains original log line. When you run Logveil, column names will be matched against your anonymization data.
-
-You can easily extract log data in such format from your Logmanager. Refer to Logmanager documentation for more info on how to Export data.
+```
+"{"original":"test.user@test.cz","new":"ladislav.dosek"}"
+"{"original":"TESTuser.test.com","new":"Apple"}"
+```
 
 ### Anonymization data
 
-Each column for which you want to anonymize data must have its equivalent in anonymization data folder.
+Each `key:value` pair which you want to anonymize data must have its equivalent in anonymization data folder.
 
-For example, if you want to anonymize values in `msg.src_ip` and `msg.username` columns, you need to have two files of the same name in anonymization folder.
+For example, if you want to anonymize values in `organization` and `username` keys, you need to have two files of the same name in anonymization folder containing some random data.
 
 ### Output
 
-Anonymized data will be outputted to provided file path in txt format (unparsed).
+Anonymized data will be outputted to provided file path in txt format.
 
 Alternatively, if you don't provide file path, output will be written to the console.
 

--- a/cmd/logveil/logveil.go
+++ b/cmd/logveil/logveil.go
@@ -10,6 +10,7 @@ import (
 	"github.com/logmanager-oss/logveil/internal/anonymizer"
 	"github.com/logmanager-oss/logveil/internal/config"
 	"github.com/logmanager-oss/logveil/internal/files"
+	"github.com/logmanager-oss/logveil/internal/proof"
 	"github.com/logmanager-oss/logveil/internal/reader"
 	"github.com/logmanager-oss/logveil/internal/writer"
 )
@@ -20,7 +21,7 @@ func Start() {
 	config := &config.Config{}
 	config.LoadAndValidate()
 
-	if *config.IsVerbose {
+	if config.IsVerbose {
 		slog.SetLogLoggerLevel(slog.LevelDebug)
 	}
 
@@ -35,7 +36,11 @@ func Start() {
 	if err != nil {
 		return
 	}
-	anonymizerDoer, err := anonymizer.CreateAnonymizer(config)
+	proofWriter, err := proof.CreateProofWriter(config, filesHandler)
+	if err != nil {
+		return
+	}
+	anonymizerDoer, err := anonymizer.CreateAnonymizer(config, proofWriter)
 	if err != nil {
 		return
 	}

--- a/internal/anonymizer/anonymizer.go
+++ b/internal/anonymizer/anonymizer.go
@@ -7,28 +7,33 @@ import (
 
 	"github.com/logmanager-oss/logveil/internal/config"
 	"github.com/logmanager-oss/logveil/internal/loader"
+	"github.com/logmanager-oss/logveil/internal/proof"
 	"golang.org/x/exp/rand"
 )
 
 // Anonymizer represents an object responsible for anonymizing indivisual log lines feed to it. It contains anonymization data which will be used to anonymize input and a random number generator funtion used to select values from anonymization data.
 type Anonymizer struct {
-	anonData map[string][]string
-	randFunc func(int) int
+	anonData    map[string][]string
+	randFunc    func(int) int
+	proofWriter *proof.ProofWriter
 }
 
-func CreateAnonymizer(config *config.Config) (*Anonymizer, error) {
+func CreateAnonymizer(config *config.Config, proofWriter *proof.ProofWriter) (*Anonymizer, error) {
 	anonymizingData, err := loader.Load(config.AnonymizationDataPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading anonymizing data from dir %s: %v", config.AnonymizationDataPath, err)
 	}
 
 	return &Anonymizer{
-		anonData: anonymizingData,
-		randFunc: rand.Intn,
+		anonData:    anonymizingData,
+		randFunc:    rand.Intn,
+		proofWriter: proofWriter,
 	}, nil
 }
 
 func (an *Anonymizer) Anonymize(logLine map[string]string) string {
+	defer an.proofWriter.Flush()
+
 	for field, value := range logLine {
 		if field == "raw" {
 			continue
@@ -40,6 +45,8 @@ func (an *Anonymizer) Anonymize(logLine map[string]string) string {
 
 		if anonValues, exists := an.anonData[field]; exists {
 			newAnonValue := anonValues[an.randFunc(len(anonValues))]
+
+			an.proofWriter.Write(value, newAnonValue)
 
 			slog.Debug(fmt.Sprintf("Replacing the values for field %s. From %s to %s.\n", field, value, newAnonValue))
 

--- a/internal/anonymizer/anonymizer_test.go
+++ b/internal/anonymizer/anonymizer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/logmanager-oss/logveil/internal/config"
+	"github.com/logmanager-oss/logveil/internal/proof"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,7 @@ func TestAnonimizer_AnonymizeData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			anonymizer, err := CreateAnonymizer(&config.Config{AnonymizationDataPath: tt.anonymizingDataDir})
+			anonymizer, err := CreateAnonymizer(&config.Config{AnonymizationDataPath: tt.anonymizingDataDir}, &proof.ProofWriter{IsEnabled: false})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,9 @@ type Config struct {
 	AnonymizationDataPath string
 	InputPath             string
 	OutputPath            string
-	IsVerbose             *bool
-	IsLmExport            *bool
+	IsVerbose             bool
+	IsLmExport            bool
+	IsProofWriter         bool
 }
 
 // LoadAndValidate loads values from user supplied input into Config struct and validates them
@@ -21,8 +22,9 @@ func (c *Config) LoadAndValidate() {
 
 	flag.Func("o", "Path to output file (default: Stdout)", validateOutput(c.OutputPath))
 
-	c.IsVerbose = flag.Bool("v", false, "Enable verbose logging (default: Disabled)")
-	c.IsLmExport = flag.Bool("e", false, "Change input file type to LM export (default: LM Backup)")
+	flag.BoolVar(&c.IsVerbose, "v", false, "Enable verbose logging (default: Disabled)")
+	flag.BoolVar(&c.IsLmExport, "e", false, "Change input file type to LM export (default: LM Backup)")
+	flag.BoolVar(&c.IsProofWriter, "p", true, "Disable proof wrtier (default: Enabled)")
 
 	flag.Parse()
 }

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -1,0 +1,68 @@
+package proof
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/logmanager-oss/logveil/internal/config"
+	"github.com/logmanager-oss/logveil/internal/files"
+)
+
+type ProofWriter struct {
+	IsEnabled bool
+	writer    *bufio.Writer
+	file      *os.File
+}
+
+func CreateProofWriter(config *config.Config, openFiles *files.FilesHandler) (*ProofWriter, error) {
+	if config.IsProofWriter {
+		file, err := os.Create("proof.json")
+		if err != nil {
+			return nil, fmt.Errorf("creating/opening proof file: %v", err)
+		}
+		openFiles.Add(file)
+
+		return &ProofWriter{
+			IsEnabled: true,
+			writer:    bufio.NewWriter(file),
+			file:      file,
+		}, nil
+	}
+
+	return &ProofWriter{IsEnabled: false}, nil
+}
+
+func (p *ProofWriter) Write(originalValue string, maskedValue string) {
+	if !p.IsEnabled {
+		return
+	}
+
+	proof := struct {
+		OriginalValue string `json:"original"`
+		MaskedValue   string `json:"new"`
+	}{
+		OriginalValue: originalValue,
+		MaskedValue:   maskedValue,
+	}
+
+	bytes, err := json.Marshal(proof)
+	if err != nil {
+		slog.Error("marshalling anonymisation proof", "error", err)
+	}
+
+	_, err = fmt.Fprintf(p.writer, "%s\n", bytes)
+	if err != nil {
+		slog.Error("writing anonymisation proof", "error", err)
+	}
+}
+
+func (p *ProofWriter) Flush() {
+	if !p.IsEnabled {
+		return
+	}
+
+	p.writer.Flush()
+}

--- a/internal/proof/proof_test.go
+++ b/internal/proof/proof_test.go
@@ -1,0 +1,68 @@
+package proof
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/logmanager-oss/logveil/internal/config"
+	"github.com/logmanager-oss/logveil/internal/files"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProof_Write(t *testing.T) {
+	tests := []struct {
+		name           string
+		isProofWriter  bool
+		originalValue  string
+		maskedValue    string
+		expectedOutput string
+	}{
+		{
+			name:           "Test case 1: write proof",
+			isProofWriter:  true,
+			originalValue:  "test",
+			maskedValue:    "masked",
+			expectedOutput: "{\"original\":\"test\",\"new\":\"masked\"}\n",
+		},
+		{
+			name:           "Test case 2: proof writer disabled",
+			isProofWriter:  false,
+			originalValue:  "test",
+			maskedValue:    "masked",
+			expectedOutput: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filesHandler := &files.FilesHandler{}
+			defer filesHandler.Close()
+
+			p, err := CreateProofWriter(&config.Config{IsProofWriter: tt.isProofWriter}, filesHandler)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			p.Write(tt.originalValue, tt.maskedValue)
+			p.Flush()
+
+			file, err := os.OpenFile("proof.json", os.O_RDWR|os.O_CREATE, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			buf := bytes.NewBuffer(nil)
+			_, err = io.Copy(buf, file)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			file.Close()
+
+			assert.Equal(t, tt.expectedOutput, buf.String())
+
+			os.Remove("proof.json")
+		})
+	}
+}

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/logmanager-oss/logveil/internal/config"
-	file "github.com/logmanager-oss/logveil/internal/files"
+	"github.com/logmanager-oss/logveil/internal/files"
 )
 
 type InputReader interface {
@@ -13,14 +13,14 @@ type InputReader interface {
 	Close() error
 }
 
-func CreateInputReader(config *config.Config, openFiles *file.FilesHandler) (InputReader, error) {
+func CreateInputReader(config *config.Config, openFiles *files.FilesHandler) (InputReader, error) {
 	inputFile, err := os.Open(config.InputPath)
 	if err != nil {
 		return nil, fmt.Errorf("opening input file for reading: %v", err)
 	}
 	openFiles.Add(inputFile)
 
-	if *config.IsLmExport {
+	if config.IsLmExport {
 		inputReader, err := NewLmExportReader(inputFile)
 		if err != nil {
 			return nil, fmt.Errorf("initializin LM Export reader: %v", err)

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -7,13 +7,13 @@ import (
 	"os"
 
 	"github.com/logmanager-oss/logveil/internal/config"
-	file "github.com/logmanager-oss/logveil/internal/files"
+	"github.com/logmanager-oss/logveil/internal/files"
 )
 
-func CreateOutputWriter(configFile *config.Config, openFiles *file.FilesHandler) (*bufio.Writer, error) {
+func CreateOutputWriter(config *config.Config, openFiles *files.FilesHandler) (*bufio.Writer, error) {
 	var outputFile *os.File
-	if configFile.OutputPath != "" {
-		outputFile, err := os.Create(configFile.OutputPath)
+	if config.OutputPath != "" {
+		outputFile, err := os.Create(config.OutputPath)
 		if err != nil {
 			return nil, fmt.Errorf("opening output file for writing: %v", err)
 		}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3,65 +3,78 @@ package testing
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/logmanager-oss/logveil/cmd/logveil"
 	"github.com/logmanager-oss/logveil/internal/anonymizer"
 	"github.com/logmanager-oss/logveil/internal/config"
+	"github.com/logmanager-oss/logveil/internal/files"
+	"github.com/logmanager-oss/logveil/internal/proof"
 	"github.com/logmanager-oss/logveil/internal/reader"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLogVeil_IntegrationTest(t *testing.T) {
 	tests := []struct {
-		name               string
-		inputFilename      string
-		isLmExport         bool
-		anonymizingDataDir string
-		expectedOutput     string
+		name           string
+		config         *config.Config
+		expectedOutput string
+		expectedProof  []map[string]interface{}
 	}{
 		{
-			name:               "Test Test LM Backup Anonymizer",
-			inputFilename:      "data/lm_backup_test_input.gz",
-			isLmExport:         false,
-			anonymizingDataDir: "data/anonymization_data",
-			expectedOutput:     "<189>date=2024-11-06 time=12:29:25 devname=\"LM-FW-70F-Praha\" devid=\"FGT70FTK22012016\" eventtime=1730892565525108329 tz=\"+0100\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=10.20.0.53 srcport=57158 srcintf=\"lan1\" srcintfrole=\"wan\" dstip=227.51.221.89 dstport=80 dstintf=\"lan1\" dstintfrole=\"lan\" srccountry=\"China\" dstcountry=\"Czech Republic\" sessionid=179455916 proto=6 action=\"client-rst\" policyid=9 policytype=\"policy\" poluuid=\"d8ccb3e4-74d4-51ef-69a3-73b41f46df74\" policyname=\"Gitlab web from all\" service=\"HTTP\" trandisp=\"noop\" duration=6 sentbyte=80 rcvdbyte=44 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" srchwvendor=\"H3C\" devtype=\"Router\" mastersrcmac=\"00:23:89:39:a4:ef\" srcmac=\"00:23:89:39:a4:ef\" srcserver=0 dsthwvendor=\"H3C\" dstdevtype=\"Router\" masterdstmac=\"00:23:89:39:a4:fa\" dstmac=\"00:23:89:39:a4:fa\" dstserver=0\n",
+			name: "Test Test LM Backup Anonymizer",
+			config: &config.Config{
+				AnonymizationDataPath: "data/anonymization_data",
+				InputPath:             "data/lm_backup_test_input.gz",
+				IsLmExport:            false,
+				IsProofWriter:         true,
+			},
+			expectedOutput: "<189>date=2024-11-06 time=12:29:25 devname=\"LM-FW-70F-Praha\" devid=\"FGT70FTK22012016\" eventtime=1730892565525108329 tz=\"+0100\" logid=\"0000000013\" type=\"traffic\" subtype=\"forward\" level=\"notice\" vd=\"root\" srcip=10.20.0.53 srcport=57158 srcintf=\"lan1\" srcintfrole=\"wan\" dstip=227.51.221.89 dstport=80 dstintf=\"lan1\" dstintfrole=\"lan\" srccountry=\"China\" dstcountry=\"Czech Republic\" sessionid=179455916 proto=6 action=\"client-rst\" policyid=9 policytype=\"policy\" poluuid=\"d8ccb3e4-74d4-51ef-69a3-73b41f46df74\" policyname=\"Gitlab web from all\" service=\"HTTP\" trandisp=\"noop\" duration=6 sentbyte=80 rcvdbyte=44 sentpkt=2 rcvdpkt=1 appcat=\"unscanned\" srchwvendor=\"H3C\" devtype=\"Router\" mastersrcmac=\"00:23:89:39:a4:ef\" srcmac=\"00:23:89:39:a4:ef\" srcserver=0 dsthwvendor=\"H3C\" dstdevtype=\"Router\" masterdstmac=\"00:23:89:39:a4:fa\" dstmac=\"00:23:89:39:a4:fa\" dstserver=0\n",
+			expectedProof: []map[string]interface{}{
+				{"original": "dev-uplink", "new": "lan1"},
+				{"original": "95.80.197.108", "new": "227.51.221.89"},
+				{"original": "27.221.126.209", "new": "10.20.0.53"},
+				{"original": "wan1-lm", "new": "lan1"},
+			},
 		},
 		{
-			name:               "Test LM Export Anonymizer",
-			inputFilename:      "data/lm_export_test_input.csv",
-			isLmExport:         true,
-			anonymizingDataDir: "data/anonymization_data",
-			expectedOutput:     "{\"@timestamp\": \"2024-06-05T14:59:27.000+00:00\", \"msg.src_ip\":\"10.20.0.53\", \"username\":\"ladislav.dosek\", \"organization\":\"Apple\"}\n",
+			name: "Test LM Export Anonymizer",
+			config: &config.Config{
+				AnonymizationDataPath: "data/anonymization_data",
+				InputPath:             "data/lm_export_test_input.csv",
+				IsLmExport:            true,
+				IsProofWriter:         true,
+			},
+			expectedOutput: "{\"@timestamp\": \"2024-06-05T14:59:27.000+00:00\", \"msg.src_ip\":\"10.20.0.53\", \"username\":\"ladislav.dosek\", \"organization\":\"Apple\"}\n",
+			expectedProof: []map[string]interface{}{
+				{"original": "89.239.31.49", "new": "10.20.0.53"},
+				{"original": "test.user@test.cz", "new": "ladislav.dosek"},
+				{"original": "TESTuser.test.com", "new": "Apple"},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inputFile, err := os.Open(tt.inputFilename)
+			filesHandler := &files.FilesHandler{}
+			defer filesHandler.Close()
+
+			inputReader, err := reader.CreateInputReader(tt.config, filesHandler)
 			if err != nil {
 				t.Fatal(err)
-			}
-			defer inputFile.Close()
-
-			var inputReader reader.InputReader
-			if tt.isLmExport {
-				inputReader, err = reader.NewLmExportReader(inputFile)
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				inputReader, err = reader.NewLmBackupReader(inputFile)
-				if err != nil {
-					t.Fatal(err)
-				}
 			}
 
 			var output bytes.Buffer
 			outputWriter := bufio.NewWriter(&output)
 
-			anonymizer, err := anonymizer.CreateAnonymizer(&config.Config{AnonymizationDataPath: tt.anonymizingDataDir})
+			proofWriter, err := proof.CreateProofWriter(tt.config, filesHandler)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			anonymizer, err := anonymizer.CreateAnonymizer(tt.config, proofWriter)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -74,6 +87,44 @@ func TestLogVeil_IntegrationTest(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedOutput, output.String())
+
+			actualProof, err := unpackProofOutput()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.ElementsMatch(t, tt.expectedProof, actualProof)
+
+			err = os.Remove("proof.json")
+			if err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
+}
+
+func unpackProofOutput() ([]map[string]interface{}, error) {
+	outputFile, err := os.OpenFile("proof.json", os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	var output []map[string]interface{}
+	scanner := bufio.NewScanner(outputFile)
+	for scanner.Scan() {
+		var unpackedLine map[string]interface{}
+		line := scanner.Bytes()
+		err := json.Unmarshal(line, &unpackedLine)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, unpackedLine)
+	}
+
+	err = scanner.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
 }


### PR DESCRIPTION
Added a possibility (enabled by default) to output proof.json file which contains replacement info in format:

{"original": "originalValue", "new": "newValue"}